### PR TITLE
updated file reads to support utf-8-sig (BOM) encoding for .json files

### DIFF
--- a/api_clients.py
+++ b/api_clients.py
@@ -324,7 +324,7 @@ class MetadataFetcher:
                         f"limit 5;" # Keep limit low for individual searches
                     )
                     json_bytes = igdb_wrapper_instance.api_request('games', api_query)
-                    games_data = json.loads(json_bytes.decode('utf-8'))
+                    games_data = json.loads(json_bytes.decode('utf-8-sig'))
 
                     if games_data:
                         highest_similarity_ratio = 0.0

--- a/config_manager.py
+++ b/config_manager.py
@@ -21,7 +21,7 @@ def load_config():
         return # No config file yet, will use defaults or prompt
 
     try:
-        config.read(CONFIG_FILE_PATH, encoding='utf-8')
+        config.read(CONFIG_FILE_PATH, encoding='utf-8-sig')
         if 'settings' in config:
             app_config["apollo_conf_path"] = config['settings'].get("apollo_conf_path")
             app_config["steamgriddb_api_key"] = config['settings'].get("steamgriddb_api_key")

--- a/utils.py
+++ b/utils.py
@@ -95,11 +95,11 @@ def collect_data(apps_json: Path, state_json: Path):
     if not state_json.exists():
         raise FileNotFoundError(f"state.json not found at {state_json}")
 
-    with state_json.open(encoding="utf-8") as f:
+    with state_json.open(encoding="utf-8-sig") as f:
         host_uuid = json.load(f)["root"]["uniqueid"]
 
     app_map = {}
-    with apps_json.open(encoding="utf-8") as f:
+    with apps_json.open(encoding="utf-8-sig") as f:
         for app in json.load(f)["apps"]:
             name  = app.get("name")
             uuid  = app.get("uuid")


### PR DESCRIPTION
I ran into an issue where another tool that modifies the apps.json file (perhaps the Playnite Sunshine App Export extenstion) was saving the file as a BOM UTF-8 file, and this was causing ApolloLauncherExport to quietly fail.  I fixed this by changing the relevant file reads to use utf-8-sig rather than vanilla utf-8.